### PR TITLE
Allow custom CSS selection and make template optional

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -9,11 +9,18 @@
  *
  */
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'mpdftemplate';
-$GLOBALS['TL_DCA']['tl_page']['palettes']['root'] = str_replace('{cache_legend', '{pdf_legend:hide},mpdftemplate;{cache_legend', $GLOBALS['TL_DCA']['tl_page']['palettes']['root']);
+
+PaletteManipulator::create()
+    ->addLegend('pdf_legend', 'cache_legend')
+    ->addField('mpdftemplate', 'pdf_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('root', 'tl_page')
+;
 
 // add subpalette
-$GLOBALS['TL_DCA']['tl_page']['subpalettes']['mpdftemplate'] = 'pdfTplSRC,pdfMargin,pdfIgnoreCSS';
+$GLOBALS['TL_DCA']['tl_page']['subpalettes']['mpdftemplate'] = 'pdfTplSRC,pdfMargin,pdfIgnoreCSS,pdfCustomCSS';
 
 // add fields
 $GLOBALS['TL_DCA']['tl_page']['fields']['mpdftemplate'] = array
@@ -30,7 +37,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['pdfTplSRC'] = array
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['pdfTplSRC'],
     'exclude'                 => true,
     'inputType'               => 'fileTree',
-    'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'mandatory'=>true, 'tl_class'=>'clr', 'extensions'=>'pdf'),
+    'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'tl_class'=>'clr', 'extensions'=>'pdf'),
     'sql'                     => "binary(16) NULL",
 );
 
@@ -49,6 +56,15 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['pdfIgnoreCSS'] = array
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['pdfIgnoreCSS'],
     'exclude'                 => true,
     'inputType'               => 'checkbox',
-    'eval'                    => array('tl_class'=>'w50 m12'),
+    'eval'                    => array('tl_class'=>'w50 clr'),
     'sql'                     => "char(1) NOT NULL default ''"
+);
+
+$GLOBALS['TL_DCA']['tl_page']['fields']['pdfCustomCSS'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_page']['pdfCustomCSS'],
+    'exclude'                 => true,
+    'inputType'               => 'fileTree',
+    'eval'                    => array('filesOnly'=>true, 'fieldType'=>'checkbox', 'tl_class'=>'clr', 'extensions'=>'css', 'multiple'=>true),
+    'sql'                     => "blob NULL"
 );

--- a/src/Resources/contao/languages/de/tl_page.php
+++ b/src/Resources/contao/languages/de/tl_page.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_page']['mpdftemplate'] = array('PDF-Ausgabe mit PDF-Vorl
 $GLOBALS['TL_LANG']['tl_page']['pdfTplSRC']    = array('PDF-Vorlagedatei', 'Geben Sie eine Vorlagedatei an, die für PDF-Ausgaben verwendet werden soll.');
 $GLOBALS['TL_LANG']['tl_page']['pdfMargin']    = array('Randbereiche', 'Passen Sie die Ränder oben, rechts, unten, links an die Vorlagedatei an.');
 $GLOBALS['TL_LANG']['tl_page']['pdfIgnoreCSS'] = array($GLOBALS['TL_CONFIG']['uploadPath'].'/mpdf.css ignorieren', 'Das mPDF-Stylesheet '.$GLOBALS['TL_CONFIG']['uploadPath'].'/mpdf.css nicht einbinden.');
+$GLOBALS['TL_LANG']['tl_page']['pdfCustomCSS'] = array('Eigenes CSS', 'Die ausgewählten Stylesheets werden bei der PDF Ausgabe inkludiert.');
 
 /**
  * Legends

--- a/src/Resources/contao/languages/en/tl_page.php
+++ b/src/Resources/contao/languages/en/tl_page.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_page']['mpdftemplate'] = array('PDF output with PDF temp
 $GLOBALS['TL_LANG']['tl_page']['pdfTplSRC']    = array('PDF template file', 'Enter a template file that will be used for PDF output.');
 $GLOBALS['TL_LANG']['tl_page']['pdfMargin']    = array('Marginal areas', 'Adjust the margins up, right, bottom and left corresponding to the template file.');
 $GLOBALS['TL_LANG']['tl_page']['pdfIgnoreCSS'] = array('Skip '.$GLOBALS['TL_CONFIG']['uploadPath'].'/mpdf.css', 'Do not include the mPDF style sheet ('.$GLOBALS['TL_CONFIG']['uploadPath'].'/mpdf.css).');
+$GLOBALS['TL_LANG']['tl_page']['pdfCustomCSS'] = array('Custom CSS', 'The selected stylesheets will be included in the PDF output.');
 
 /**
  * Legends


### PR DESCRIPTION
I think it makes sense to use this bundle even if you do not need an actual PDF template. For example, if you just need custom CSS. This PR changes the following:

* The template file is now optional.
* You can now select any CSS file to be included in the PDF rendering.