### PR TITLE
Allow mpdf/mpdf ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.0",
         "contao/core-bundle": "~4.4",
-        "mpdf/mpdf": "^7.0"
+        "mpdf/mpdf": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As far as I tested, it should be save to also allow version 8.0 of mPDF.