### PR TITLE
Add PDF generation events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "contao/core-bundle": "~4.9",
         "contao/tcpdf-bundle": "^1.2",
         "mpdf/mpdf": "^7.0 || ^8.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3.0"
+        "symfony/event-dispatcher-contracts": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
         "source": "https://github.com/do-while/contao-mpdf-template-bundle"
     },
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "contao/core-bundle": "~4.9",
         "contao/tcpdf-bundle": "^1.2",
-        "mpdf/mpdf": "^7.0 || ^8.0"
+        "mpdf/mpdf": "^7.0 || ^8.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -41,5 +42,11 @@
     },
     "extra": {
 		"contao-manager-plugin": "Softleister\\MpdftemplateBundle\\ContaoManager\\Plugin"
+    },
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "php-http/discovery": true
+        }
     }
 }

--- a/src/Event/ArticleAsPdfEvent.php
+++ b/src/Event/ArticleAsPdfEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Softleister\MpdftemplateBundle\Event;
+
+use Contao\ModuleArticle;
+use Mpdf\Mpdf;
+
+abstract class ArticleAsPdfEvent
+{
+    private ModuleArticle $article;
+    
+    private Mpdf $pdf;
+
+    public function __construct(ModuleArticle $article, Mpdf $pdf)
+    {
+        $this->article = $article;
+        $this->pdf     = $pdf;
+    }
+    
+    public function getArticle(): ModuleArticle
+    {
+        return $this->article;
+    }
+    
+    public function getPdf(): Mpdf
+    {
+        return $this->pdf;
+    }
+}

--- a/src/Event/BeforeOutputArticleAsPdfEvent.php
+++ b/src/Event/BeforeOutputArticleAsPdfEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Softleister\MpdftemplateBundle\Event;
+
+use Contao\ModuleArticle;
+use Mpdf\Mpdf;
+
+final class BeforeOutputArticleAsPdfEvent extends ArticleAsPdfEvent
+{
+    private string $filename;
+
+    public function __construct(ModuleArticle $article, Mpdf $pdf, string $filename)
+    {
+        parent::__construct($article, $pdf);
+        $this->filename = $filename;
+    }
+    
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+}

--- a/src/Event/BeforeOutputArticleAsPdfEvent.php
+++ b/src/Event/BeforeOutputArticleAsPdfEvent.php
@@ -21,4 +21,9 @@ final class BeforeOutputArticleAsPdfEvent extends ArticleAsPdfEvent
     {
         return $this->filename;
     }
+
+    public function setFilename(string $filename): void
+    {
+        $this->filename = $filename;
+    }
 }

--- a/src/Event/BeforeWriteArticleAsPdfEvent.php
+++ b/src/Event/BeforeWriteArticleAsPdfEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Softleister\MpdftemplateBundle\Event;
+
+use Contao\ModuleArticle;
+use Mpdf\Mpdf;
+
+final class BeforeWriteArticleAsPdfEvent extends ArticleAsPdfEvent
+{
+    private string $html;
+
+    public function __construct(ModuleArticle $article, Mpdf $pdf, string $html)
+    {
+        parent::__construct($article, $pdf);
+
+        $this->html = $html;
+    }
+    
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+}


### PR DESCRIPTION
This update introduces new PDF generation events that can be dispatched before writing an HTML file to a PDF and before outputting a generated PDF. This allows an extension point for any further processing or modification before writing an article as a PDF or before outputting the generated PDF.

/cc @frontendschlampe